### PR TITLE
Run detail restyled, added pace data

### DIFF
--- a/src/components/RunDetail/RunDetail.jsx
+++ b/src/components/RunDetail/RunDetail.jsx
@@ -15,6 +15,10 @@ const RunDetail = ({ user, run, setRun }) => {
   let start = new moment(displayRun.start);
   let end = new moment(displayRun.end);
   displayRun.elapsedTime = moment.duration(end.diff(start));
+  const seconds = moment.duration(end.diff(start)).as('seconds');
+  const pace = seconds / displayRun.distance;
+  const paceMinutes = Math.floor(pace / 60);
+  const paceSeconds = Math.round(pace % 60);
 
   return (
     <>
@@ -29,12 +33,13 @@ const RunDetail = ({ user, run, setRun }) => {
                 text='Close'
                 eventHandler={() => setRun({})} />
             </div>
-            <h5><Moment date={displayRun.start} format='Do MMMM, YYYY, h:mm a' /></h5>
-            <h3>{displayRun.title}</h3>
+            <h2>{displayRun.title}</h2>
+            <h3><Moment date={displayRun.start} format='Do MMMM, YYYY, h:mm a' /></h3>
             <p>Distance: {displayRun.distance}km</p>
             <p>Elapsed time: {displayRun.elapsedTime.format('h:mm:ss')}</p>
+            <p>Pace: {paceMinutes}:{paceSeconds < 10 ? `0${paceSeconds}` : paceSeconds}/km</p>
             <p>Workout type: {displayRun.workoutType}</p>
-            <p>Notes: {displayRun.notes}</p>
+            {displayRun.notes && <p>Notes: {displayRun.notes}</p>}
             <div className={runStyles.buttonContainer}>
               <Button
                 buttonType='button'

--- a/src/components/RunDetail/RunDetail.module.scss
+++ b/src/components/RunDetail/RunDetail.module.scss
@@ -1,11 +1,37 @@
 @import '../../styles/variables.scss';
+@import '../../styles/mixins.scss';
 
 .runDetailSection {
   grid-column: 6 / -2;
   color: $white;
-  padding: 6rem 0 4rem;
+  padding: 6rem 0;
+  @include respond-to('tablet') {
+    grid-column: 4 / -2;
+  }
+  @include respond-to('mobile') {
+    grid-column: 2 / -2;
+  }
 }
-
+.runDetailSection h2 {
+  color: $primary;
+  font-size: 3.2rem;
+  margin-top: -4.8rem;
+  margin-bottom: 3rem;
+}
+.runDetailSection h4 {
+  margin-bottom: 5rem;
+}
+.runDetailSection p {
+  font-size: 2.0rem;
+  line-height: 1.6;
+  margin-bottom: 2.4rem;
+}
+.closeContainer {
+  text-align: right;
+}
+.buttonContainer {
+  margin-top: 6rem;
+}
 .buttonContainer button:first-of-type {
   margin-right: 2rem;
 }

--- a/src/components/UserHome/UserHome.module.scss
+++ b/src/components/UserHome/UserHome.module.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables.scss';
+@import '../../styles/mixins.scss';
 
 .sideNav {
   grid-column: 2 / 6;
@@ -23,3 +24,21 @@
   color: $primary;
   font-weight: 800;
 }
+
+  @include respond-to('tablet') {
+    .sideNav {
+      grid-column: 2 / 4;
+    }
+  }
+  @include respond-to('mobile') {
+    .sideNav {
+      grid-column: 2 / -2;
+    }
+    .sideNav ul {
+      display: flex;
+      justify-content: flex-start;
+    }
+    .sideNav li:not(:last-of-type) {
+      margin-right: 3rem;
+    }
+  }


### PR DESCRIPTION
Closes #27 

- Styles run detail page a little nicer on desktop and mobile
- Adds calculation to show pace
- Navigating away still requires clicking 'close'; clicking side nav won't work until we re-do how the calendar navigates to run pages, which is going to be a whole thing